### PR TITLE
Update requirements.txt to pin pymodbus to compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyModbusTCP
-pymodbus
+pymodbus==3.9.2


### PR DESCRIPTION
Pinning to a version that works.

the latest versions error with something like:


python modbus_test.py 
Traceback (most recent call last):
  File "/b/py-modbus-api-client/modbus_test.py", line 5, in <module>
    from peblar_modbusclient.modbus import Modbus
  File "/b/py-modbus-api-client/peblar_modbusclient/modbus.py", line 6, in <module>
    from .registers import ModbusAddress, ModbusAddresses
  File "/b/py-modbus-api-client/peblar_modbusclient/registers.py", line 7, in <module>
    from pymodbus.constants import Endian
ImportError: cannot import name 'Endian' from 'pymodbus.constants' (/usr/local/lib/python3.13/site-packages/pymodbus/constants.py)